### PR TITLE
specify cpp standard to compiler

### DIFF
--- a/implot-sys/build.rs
+++ b/implot-sys/build.rs
@@ -55,6 +55,7 @@ fn main() -> io::Result<()> {
 
     // Taken from the imgui-sys build as well
     build.flag_if_supported("-Wno-return-type-c-linkage");
+    build.flag_if_supported("-std=c++11");
     for path in CPP_FILES {
         assert_file_exists(path)?;
         build.file(path);


### PR DESCRIPTION
otherwise I get the following on `Apple LLVM version 10.0.1 (clang-1001.0.46.4)`
```
  cargo:warning=third-party/cimplot/implot/implot_demo.cpp:1429:41: error: a space is required between consecutive right angle brackets (use '> >')
  cargo:warning=    static ImVector<ImVector<ImPlotPoint>> records;
  cargo:warning=                                        ^~
  cargo:warning=                                        > >
  cargo:warning=1 warning and 1 error generated.
  exit code: 1
```