### PR TITLE
Use slices instead of Vecs in function parameters

### DIFF
--- a/src/plot.rs
+++ b/src/plot.rs
@@ -231,8 +231,8 @@ impl Plot {
     /// the form of a tuple `(label_position, label_string)`. The `show_default` setting
     /// determines whether the default ticks are also shown.
     #[inline]
-    pub fn x_ticks(mut self, ticks: &Vec<f64>, show_default: bool) -> Self {
-        self.x_tick_positions = Some(ticks.clone());
+    pub fn x_ticks(mut self, ticks: &[f64], show_default: bool) -> Self {
+        self.x_tick_positions = Some(ticks.into());
         self.show_x_default_ticks = show_default;
         self
     }
@@ -244,11 +244,11 @@ impl Plot {
     pub fn y_ticks(
         mut self,
         y_axis_choice: YAxisChoice,
-        ticks: &Vec<f64>,
+        ticks: &[f64],
         show_default: bool,
     ) -> Self {
         let axis_index = y_axis_choice as usize;
-        self.y_tick_positions[axis_index] = Some(ticks.clone());
+        self.y_tick_positions[axis_index] = Some(ticks.into());
         self.show_y_default_ticks[axis_index] = show_default;
         self
     }
@@ -259,7 +259,7 @@ impl Plot {
     #[inline]
     pub fn x_ticks_with_labels(
         mut self,
-        tick_labels: &Vec<(f64, String)>,
+        tick_labels: &[(f64, String)],
         show_default: bool,
     ) -> Self {
         self.x_tick_positions = Some(tick_labels.iter().map(|x| x.0).collect());
@@ -275,7 +275,7 @@ impl Plot {
     pub fn y_ticks_with_labels(
         mut self,
         y_axis_choice: YAxisChoice,
-        tick_labels: &Vec<(f64, String)>,
+        tick_labels: &[(f64, String)],
         show_default: bool,
     ) -> Self {
         let axis_index = y_axis_choice as usize;

--- a/src/plot_elements.rs
+++ b/src/plot_elements.rs
@@ -22,7 +22,7 @@ impl PlotLine {
     }
 
     /// Plot a line. Use this in closures passed to [`Plot::build()`](struct.Plot.html#method.build)
-    pub fn plot(&self, x: &Vec<f64>, y: &Vec<f64>) {
+    pub fn plot(&self, x: &[f64], y: &[f64]) {
         // If there is no data to plot, we stop here
         if x.len().min(y.len()) == 0 {
             return;
@@ -56,7 +56,7 @@ impl PlotStairs {
 
     /// Plot a stairs style line. Use this in closures passed to
     /// [`Plot::build()`](struct.Plot.html#method.build)
-    pub fn plot(&self, x: &Vec<f64>, y: &Vec<f64>) {
+    pub fn plot(&self, x: &[f64], y: &[f64]) {
         // If there is no data to plot, we stop here
         if x.len().min(y.len()) == 0 {
             return;
@@ -90,7 +90,7 @@ impl PlotScatter {
 
     /// Draw a previously-created scatter plot. Use this in closures passed to
     /// [`Plot::build()`](struct.Plot.html#method.build)
-    pub fn plot(&self, x: &Vec<f64>, y: &Vec<f64>) {
+    pub fn plot(&self, x: &[f64], y: &[f64]) {
         // If there is no data to plot, we stop here
         if x.len().min(y.len()) == 0 {
             return;
@@ -147,7 +147,7 @@ impl PlotBars {
     /// [`Plot::build()`](struct.Plot.html#method.build). The `axis_positions`
     /// specify where on the corersponding axis (X for vertical mode, Y for horizontal mode) the
     /// bar is drawn, and the `bar_values` specify what values the bars have.
-    pub fn plot(&self, axis_positions: &Vec<f64>, bar_values: &Vec<f64>) {
+    pub fn plot(&self, axis_positions: &[f64], bar_values: &[f64]) {
         let number_of_points = axis_positions.len().min(bar_values.len());
         // If there is no data to plot, we stop here
         if number_of_points == 0 {


### PR DESCRIPTION
This way we can plot e.g. arrays without having to convert them to vectors.