### PR TITLE
Use `c_char` instead of `i8` for portability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use implot_sys as sys;
 pub use self::{context::*, plot::*, plot_elements::*};
 use imgui::im_str;
 pub use sys::{ImPlotLimits, ImPlotPoint, ImPlotRange, ImVec2, ImVec4};
+use std::os::raw::c_char;
 
 mod context;
 mod plot;
@@ -575,7 +576,7 @@ pub fn is_plot_y_axis_hovered(y_axis_choice: Option<YAxisChoice>) -> bool {
 
 /// Returns true if the given item in the legend of the current plot is hovered.
 pub fn is_legend_entry_hovered(legend_entry: &str) -> bool {
-    unsafe { sys::ImPlot_IsLegendEntryHovered(im_str!("{}", legend_entry).as_ptr() as *const i8) }
+    unsafe { sys::ImPlot_IsLegendEntryHovered(im_str!("{}", legend_entry).as_ptr() as *const c_char) }
 }
 
 // --- Demo window -------------------------------------------------------------------------------

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -8,6 +8,7 @@ pub use imgui::Condition;
 use imgui::{im_str, ImString};
 use implot_sys as sys;
 use std::{cell::RefCell, rc::Rc};
+use std::os::raw::c_char;
 pub use sys::{ImPlotLimits, ImPlotPoint, ImPlotRange, ImVec2, ImVec4};
 
 const DEFAULT_PLOT_SIZE_X: f32 = 400.0;
@@ -491,8 +492,8 @@ impl Plot {
             let labels_pointer = if let Some(labels_value) = &self.x_tick_labels {
                 pointer_vec = labels_value
                     .iter()
-                    .map(|x| x.as_ptr() as *const i8)
-                    .collect::<Vec<*const i8>>();
+                    .map(|x| x.as_ptr() as *const c_char)
+                    .collect::<Vec<*const c_char>>();
                 pointer_vec.as_mut_ptr()
             } else {
                 std::ptr::null_mut()
@@ -520,8 +521,8 @@ impl Plot {
                     let labels_pointer = if let Some(labels_value) = &labels {
                         pointer_vec = labels_value
                             .iter()
-                            .map(|x| x.as_ptr() as *const i8)
-                            .collect::<Vec<*const i8>>();
+                            .map(|x| x.as_ptr() as *const c_char)
+                            .collect::<Vec<*const c_char>>();
                         pointer_vec.as_mut_ptr()
                     } else {
                         std::ptr::null_mut()

--- a/src/plot_elements.rs
+++ b/src/plot_elements.rs
@@ -5,6 +5,7 @@
 //! see `plot`.
 use crate::sys;
 use imgui::{im_str, ImString};
+use std::os::raw::c_char;
 
 pub use crate::sys::ImPlotPoint;
 
@@ -31,7 +32,7 @@ impl PlotLine {
         }
         unsafe {
             sys::ImPlot_PlotLinedoublePtrdoublePtr(
-                im_str!("{}", self.label).as_ptr() as *const i8,
+                im_str!("{}", self.label).as_ptr() as *const c_char,
                 x.as_ptr(),
                 y.as_ptr(),
                 x.len().min(y.len()) as i32, // "as" casts saturate as of Rust 1.45. This is safe here.
@@ -65,7 +66,7 @@ impl PlotStairs {
         }
         unsafe {
             sys::ImPlot_PlotStairsdoublePtrdoublePtr(
-                im_str!("{}", self.label).as_ptr() as *const i8,
+                im_str!("{}", self.label).as_ptr() as *const c_char,
                 x.as_ptr(),
                 y.as_ptr(),
                 x.len().min(y.len()) as i32, // "as" casts saturate as of Rust 1.45. This is safe here.
@@ -99,7 +100,7 @@ impl PlotScatter {
         }
         unsafe {
             sys::ImPlot_PlotScatterdoublePtrdoublePtr(
-                im_str!("{}", self.label).as_ptr() as *const i8,
+                im_str!("{}", self.label).as_ptr() as *const c_char,
                 x.as_ptr(),
                 y.as_ptr(),
                 x.len().min(y.len()) as i32, // "as" casts saturate as of Rust 1.45. This is safe here.
@@ -163,18 +164,18 @@ impl PlotBars {
             let (plot_function, x, y);
             if self.horizontal_bars {
                 plot_function = sys::ImPlot_PlotBarsHdoublePtrdoublePtr
-                    as unsafe extern "C" fn(*const i8, *const f64, *const f64, i32, f64, i32, i32);
+                    as unsafe extern "C" fn(*const c_char, *const f64, *const f64, i32, f64, i32, i32);
                 x = bar_values;
                 y = axis_positions;
             } else {
                 plot_function = sys::ImPlot_PlotBarsdoublePtrdoublePtr
-                    as unsafe extern "C" fn(*const i8, *const f64, *const f64, i32, f64, i32, i32);
+                    as unsafe extern "C" fn(*const c_char, *const f64, *const f64, i32, f64, i32, i32);
                 x = axis_positions;
                 y = bar_values;
             };
 
             plot_function(
-                im_str!("{}", self.label).as_ptr() as *const i8,
+                im_str!("{}", self.label).as_ptr() as *const c_char,
                 x.as_ptr(),
                 y.as_ptr(),
                 number_of_points as i32, // "as" casts saturate as of Rust 1.45. This is safe here.
@@ -228,7 +229,7 @@ impl PlotText {
 
         unsafe {
             sys::ImPlot_PlotText(
-                im_str!("{}", self.label).as_ptr() as *const i8,
+                im_str!("{}", self.label).as_ptr() as *const c_char,
                 x,
                 y,
                 vertical,
@@ -313,7 +314,7 @@ impl PlotHeatmap {
 
         unsafe {
             sys::ImPlot_PlotHeatmapdoublePtr(
-                im_str!("{}", self.label).as_ptr() as *const i8,
+                im_str!("{}", self.label).as_ptr() as *const c_char,
                 values.as_ptr(),
                 number_of_rows as i32, // Not sure why C++ code uses a signed value here
                 number_of_cols as i32, // Not sure why C++ code uses a signed value here
@@ -322,7 +323,7 @@ impl PlotHeatmap {
                 // "no label" is taken as null pointer in the C++ code, but we're using
                 // option types in the Rust bindings because they are more idiomatic.
                 if self.label_format.is_some() {
-                    self.label_format.as_ref().unwrap().as_ptr() as *const i8
+                    self.label_format.as_ref().unwrap().as_ptr() as *const c_char
                 } else {
                     std::ptr::null()
                 },
@@ -369,7 +370,7 @@ impl PlotStems {
         }
         unsafe {
             sys::ImPlot_PlotStemsdoublePtrdoublePtr(
-                im_str!("{}", self.label).as_ptr() as *const i8,
+                im_str!("{}", self.label).as_ptr() as *const c_char,
                 axis_positions.as_ptr(),
                 stem_values.as_ptr(),
                 number_of_points as i32, // "as" casts saturate as of Rust 1.45. This is safe here.


### PR DESCRIPTION
I had problems with compiling this crate for use on ARM where `c_char` is defined to be `u8` and not `i8`. This PR should fix this by using `c_char` instead of `i8`.