### PR TITLE
Upgrade to imgui 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 implot-sys = { version = "0.6.0", path = "implot-sys" }
-imgui = { version = "=0.7.0" }
+imgui = { version = "=0.8.0" }
 bitflags = "1.0"
 parking_lot = "0.11"
 rustversion = "1.0.4"

--- a/implot-examples/examples-shared/Cargo.toml
+++ b/implot-examples/examples-shared/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 implot = { path = "../../" }
-imgui = "=0.7.0"
+imgui = "=0.8.0"

--- a/implot-examples/examples-shared/src/bar_plots.rs
+++ b/implot-examples/examples-shared/src/bar_plots.rs
@@ -1,11 +1,11 @@
 //! This example demonstrates how bar plots are to be used. For more general
 //! features of the libray, see the line_plots example.
 
-use imgui::{im_str, CollapsingHeader, Ui};
+use imgui::{CollapsingHeader, Ui};
 use implot::{Plot, PlotBars, PlotUi};
 
 pub fn show_basic_vertical_plot(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text(im_str!("This header shows a simple vertical bar plot."));
+    ui.text("This header shows a simple vertical bar plot.");
     let content_width = ui.window_content_region_width();
     Plot::new("Vertical bar plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -22,7 +22,7 @@ pub fn show_basic_vertical_plot(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_basic_horizontal_plot(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text(im_str!("This header shows a simple horizontal bar plot."));
+    ui.text("This header shows a simple horizontal bar plot.");
     let content_width = ui.window_content_region_width();
     Plot::new("Horizontal bar plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -40,10 +40,10 @@ pub fn show_basic_horizontal_plot(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_demo_headers(ui: &Ui, plot_ui: &PlotUi) {
-    if CollapsingHeader::new(im_str!("Bar plots: Basic vertical")).build(&ui) {
-        show_basic_vertical_plot(&ui, &plot_ui);
+    if CollapsingHeader::new("Bar plots: Basic vertical").build(ui) {
+        show_basic_vertical_plot(ui, plot_ui);
     }
-    if CollapsingHeader::new(im_str!("Bar plots: Basic horizontal")).build(&ui) {
-        show_basic_horizontal_plot(&ui, &plot_ui);
+    if CollapsingHeader::new("Bar plots: Basic horizontal").build(ui) {
+        show_basic_horizontal_plot(ui, plot_ui);
     }
 }

--- a/implot-examples/examples-shared/src/heatmaps.rs
+++ b/implot-examples/examples-shared/src/heatmaps.rs
@@ -1,11 +1,11 @@
 //! This example demonstrates how heatmaps are to be used. For more general
 //! features of the libray, see the line_plots example.
 
-use imgui::{im_str, CollapsingHeader, Ui};
+use imgui::{CollapsingHeader, Ui};
 use implot::{ImPlotPoint, Plot, PlotHeatmap, PlotUi};
 
 pub fn show_basic_heatmap(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text(im_str!("This header shows a simple heatmap"));
+    ui.text("This header shows a simple heatmap");
     let content_width = ui.window_content_region_width();
     Plot::new("Heatmap plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -25,7 +25,7 @@ pub fn show_basic_heatmap(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_demo_headers(ui: &Ui, plot_ui: &PlotUi) {
-    if CollapsingHeader::new(im_str!("Heatmap: Basic")).build(&ui) {
-        show_basic_heatmap(&ui, &plot_ui);
+    if CollapsingHeader::new("Heatmap: Basic").build(ui) {
+        show_basic_heatmap(ui, plot_ui);
     }
 }

--- a/implot-examples/examples-shared/src/lib.rs
+++ b/implot-examples/examples-shared/src/lib.rs
@@ -6,7 +6,7 @@ pub mod stairs_plots;
 mod stem_plots;
 pub mod text_plots;
 
-use imgui::{im_str, Condition, Ui, Window};
+use imgui::{Condition, Ui, Window};
 use implot::PlotUi;
 
 /// State of the demo code
@@ -28,45 +28,51 @@ impl DemoState {
         // Most of the demos are currently still stateless, so the code here mostly just calls into
         // the modules. The line plots demo is stateful though. Things will be refactored soon to
         // make all the individual demos stateful to unify things more.
-        Window::new(im_str!("implot-rs demo"))
+        Window::new("implot-rs demo")
             .size([430.0, 450.0], Condition::FirstUseEver)
             .build(ui, || {
-                ui.text(im_str!("Hello from implot-rs!"));
-                ui.text_wrapped(im_str!(
+                ui.text("Hello from implot-rs!");
+                ui.text_wrapped(
                     "The headers here demo the plotting features of the library.\
                  Have a look at the example source code to see how they are implemented.\n\
                  Check out the demo from ImPlot itself first for instructions on how to\
-                 interact with ImPlot plots."
-                ));
+                 interact with ImPlot plots.",
+                );
 
                 ui.separator();
-                ui.text(im_str!("Bar plots:"));
+                ui.text("Bar plots:");
                 bar_plots::show_demo_headers(ui, plot_ui);
 
                 ui.separator();
-                ui.text(im_str!("Line plots:"));
+                ui.text("Line plots:");
                 // The line plots demo is stateful
                 self.line_plots.show_demo_headers(ui, plot_ui);
 
                 ui.separator();
-                ui.text(im_str!("Scatter plots:"));
+                ui.text("Scatter plots:");
                 scatter_plots::show_demo_headers(ui, plot_ui);
 
                 ui.separator();
-                ui.text(im_str!("Text plots:"));
+                ui.text("Text plots:");
                 text_plots::show_demo_headers(ui, plot_ui);
 
                 ui.separator();
-                ui.text(im_str!("Stairs plots:"));
+                ui.text("Stairs plots:");
                 stairs_plots::show_demo_headers(ui, plot_ui);
 
                 ui.separator();
-                ui.text(im_str!("Heatmaps:"));
+                ui.text("Heatmaps:");
                 heatmaps::show_demo_headers(ui, plot_ui);
 
                 ui.separator();
-                ui.text(im_str!("Stem plots:"));
+                ui.text("Stem plots:");
                 stem_plots::show_demo_headers(ui, plot_ui);
             });
+    }
+}
+
+impl Default for DemoState {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/implot-examples/examples-shared/src/line_plots.rs
+++ b/implot-examples/examples-shared/src/line_plots.rs
@@ -1,7 +1,7 @@
 //! This example demonstrates how line plots are to be used, along with some querying features
 //! that will be applicable to all kinds of plots.
 
-use imgui::{im_str, CollapsingHeader, Condition, Ui};
+use imgui::{CollapsingHeader, Condition, Ui};
 use implot::{
     get_plot_limits, get_plot_mouse_position, get_plot_query, is_legend_entry_hovered,
     is_plot_hovered, is_plot_queried, pixels_to_plot_vec2, plot_to_pixels_vec2, push_style_color,
@@ -27,9 +27,7 @@ impl LinePlotDemoState {
     }
 
     pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!(
-            "This header just plots a line with as little code as possible."
-        ));
+        ui.text("This header just plots a line with as little code as possible.");
         let content_width = ui.window_content_region_width();
         Plot::new("Simple line plot")
             // The size call could also be omitted, though the defaults don't consider window
@@ -44,9 +42,7 @@ impl LinePlotDemoState {
     }
 
     pub fn show_two_yaxis_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!(
-            "This header shows how to create a plot with multiple Y axes."
-        ));
+        ui.text("This header shows how to create a plot with multiple Y axes.");
         let content_width = ui.window_content_region_width();
         Plot::new("Multiple Y axis plots")
             // The size call could also be omitted, though the defaults don't consider window
@@ -79,7 +75,7 @@ impl LinePlotDemoState {
     }
 
     pub fn show_axis_equal_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!("This plot has axis equal set (1:1 aspect ratio)."));
+        ui.text("This plot has axis equal set (1:1 aspect ratio).");
         let content_width = ui.window_content_region_width();
         Plot::new("Axis equal line plot")
             // The size call could also be omitted, though the defaults don't consider window
@@ -95,9 +91,7 @@ impl LinePlotDemoState {
     }
 
     pub fn show_configurable_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!(
-            "This header demos what we can configure about plots."
-        ));
+        ui.text("This header demos what we can configure about plots.");
 
         // Settings for the plot
         // - X and Y size in pixels
@@ -127,8 +121,8 @@ impl LinePlotDemoState {
         // Axis labels
         Plot::new("Configured line plot")
             .size([x_size, y_size])
-            .x_label(&x_label)
-            .y_label(&y_label)
+            .x_label(x_label)
+            .y_label(y_label)
             .x_limits(
                 ImPlotRange {
                     Min: x_min,
@@ -156,14 +150,12 @@ impl LinePlotDemoState {
             .with_y_axis_flags(YAxisChoice::First, &y_axis_flags)
             .with_legend_location(&PlotLocation::West, &PlotOrientation::Horizontal, true)
             .build(plot_ui, || {
-                PlotLine::new("A line 2").plot(&vec![2.4, 2.9], &vec![1.1, 1.9]);
+                PlotLine::new("A line 2").plot(&[2.4, 2.9], &[1.1, 1.9]);
             });
     }
 
     pub fn show_query_features_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!(
-            "This header demos how to use the querying features."
-        ));
+        ui.text("This header demos how to use the querying features.");
         let content_width = ui.window_content_region_width();
 
         // Create some containers for exfiltrating data from the closure below
@@ -202,8 +194,8 @@ impl LinePlotDemoState {
                 ));
 
                 // Plot a line so we have a legend entry
-                PlotLine::new("Legend1").plot(&vec![2.0, 2.0], &vec![2.0, 1.0]);
-                PlotLine::new("Legend2").plot(&vec![0.0, 0.0], &vec![1.0, 1.0]);
+                PlotLine::new("Legend1").plot(&[2.0, 2.0], &[2.0, 1.0]);
+                PlotLine::new("Legend2").plot(&[0.0, 0.0], &[1.0, 1.0]);
                 legend1_hovered = is_legend_entry_hovered("Legend1");
                 legend2_hovered = is_legend_entry_hovered("Legend2");
 
@@ -217,43 +209,39 @@ impl LinePlotDemoState {
         // things like is_plot_hovered or get_plot_mouse_position() outside
         // of an actual Plot is not allowed.
         if let Some(pos) = hover_pos_plot {
-            ui.text(im_str!("hovered at {}, {}", pos.x, pos.y));
+            ui.text(format!("hovered at {}, {}", pos.x, pos.y));
         }
         if let Some(pixel_position) = hover_pos_pixels {
             // Try out converting plot mouse position to pixel position
-            ui.text(im_str!(
+            ui.text(format!(
                 "pixel pos from plot:  {}, {}",
-                pixel_position.x,
-                pixel_position.y
+                pixel_position.x, pixel_position.y
             ));
-            ui.text(im_str!(
+            ui.text(format!(
                 "pixel pos from imgui: {}, {}",
                 ui.io().mouse_pos[0],
                 ui.io().mouse_pos[1]
             ));
         }
         if let Some(limits) = plot_limits {
-            ui.text(im_str!("Plot limits are {:#?}", limits));
+            ui.text(format!("Plot limits are {:#?}", limits));
         }
         if let Some(query) = query_limits {
-            ui.text(im_str!("Query limits are {:#?}", query));
+            ui.text(format!("Query limits are {:#?}", query));
         }
-        ui.text(im_str!(
+        ui.text(format!(
             "Legend hovering - 1: {}, 2: {}",
-            legend1_hovered,
-            legend2_hovered
+            legend1_hovered, legend2_hovered
         ));
 
         // Try out converting pixel position to plot position
         if let Some(pos) = hover_pos_from_pixels {
-            ui.text(im_str!("plot pos from imgui: {}, {}", pos.x, pos.y,));
+            ui.text(format!("plot pos from imgui: {}, {}", pos.x, pos.y,));
         }
     }
 
     pub fn show_style_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!(
-            "This header demos how to use the styling features."
-        ));
+        ui.text("This header demos how to use the styling features.");
         let content_width = ui.window_content_region_width();
 
         // The style stack works the same as for other imgui things - we can push
@@ -278,14 +266,14 @@ impl LinePlotDemoState {
                 // Markers can be selected as shown here. The markers are internally represented
                 // as an u32, hence this calling style.
                 let markerchoice = push_style_var_i32(&StyleVar::Marker, Marker::Cross as i32);
-                PlotLine::new("Left eye").plot(&vec![2.0, 2.0], &vec![2.0, 1.0]);
+                PlotLine::new("Left eye").plot(&[2.0, 2.0], &[2.0, 1.0]);
                 // Calling pop() on the return value of the push above will undo the marker choice.
                 markerchoice.pop();
 
                 // Line weights can be set the same way, along with some other things - see
                 // the docs of StyleVar for more info.
                 let lineweight = push_style_var_f32(&StyleVar::LineWeight, 5.0);
-                PlotLine::new("Right eye").plot(&vec![4.0, 4.0], &vec![2.0, 1.0]);
+                PlotLine::new("Right eye").plot(&[4.0, 4.0], &[2.0, 1.0]);
                 lineweight.pop();
 
                 let x_values = vec![1.0, 2.0, 4.0, 5.0];
@@ -297,7 +285,7 @@ impl LinePlotDemoState {
     }
 
     pub fn show_colormaps_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!("This header demos how to select colormaps."));
+        ui.text("This header demos how to select colormaps.");
         let content_width = ui.window_content_region_width();
 
         // Select a colormap from the presets. The presets are listed in the Colormap enum
@@ -311,9 +299,7 @@ impl LinePlotDemoState {
             .build(plot_ui, || {
                 (1..10)
                     .map(|x| x as f64 * 0.1)
-                    .map(|x| {
-                        PlotLine::new(&format!("{:3.3}", x)).plot(&vec![0.1, 0.9], &vec![x, x])
-                    })
+                    .map(|x| PlotLine::new(&format!("{:3.3}", x)).plot(&[0.1, 0.9], &[x, x]))
                     .count();
             });
 
@@ -340,9 +326,7 @@ impl LinePlotDemoState {
             .build(plot_ui, || {
                 (1..10)
                     .map(|x| x as f64 * 0.1)
-                    .map(|x| {
-                        PlotLine::new(&format!("{:3.3}", x)).plot(&vec![0.1, 0.9], &vec![x, x])
-                    })
+                    .map(|x| PlotLine::new(&format!("{:3.3}", x)).plot(&[0.1, 0.9], &[x, x]))
                     .count();
             });
 
@@ -352,9 +336,7 @@ impl LinePlotDemoState {
     }
 
     pub fn show_conversions_plot(ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!(
-            "This header demonstrates (in code) how to convert various ranges into ImRange"
-        ));
+        ui.text("This header demonstrates (in code) how to convert various ranges into ImRange");
         let content_width = ui.window_content_region_width();
         Plot::new("Simple line plot, conversion 1")
             .size([content_width, 300.0])
@@ -369,9 +351,7 @@ impl LinePlotDemoState {
     }
 
     pub fn show_linked_x_axis_plots(&mut self, ui: &Ui, plot_ui: &PlotUi) {
-        ui.text(im_str!(
-            "These plots have their X axes linked, but not the Y axes"
-        ));
+        ui.text("These plots have their X axes linked, but not the Y axes");
         let content_width = ui.window_content_region_width();
         Plot::new("Linked plot 1")
             .size([content_width, 300.0])
@@ -392,32 +372,38 @@ impl LinePlotDemoState {
     }
 
     pub fn show_demo_headers(&mut self, ui: &Ui, plot_ui: &PlotUi) {
-        if CollapsingHeader::new(im_str!("Line plot: Basic")).build(&ui) {
-            Self::show_basic_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: Basic").build(ui) {
+            Self::show_basic_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line plot: Configured")).build(&ui) {
-            Self::show_configurable_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: Configured").build(ui) {
+            Self::show_configurable_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line Plot: Plot queries")).build(&ui) {
-            Self::show_query_features_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line Plot: Plot queries").build(ui) {
+            Self::show_query_features_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line plot: Plot styling")).build(&ui) {
-            Self::show_style_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: Plot styling").build(ui) {
+            Self::show_style_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line plot: Colormaps")).build(&ui) {
-            Self::show_colormaps_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: Colormaps").build(ui) {
+            Self::show_colormaps_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line plot: Multiple Y Axes")).build(&ui) {
-            Self::show_two_yaxis_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: Multiple Y Axes").build(ui) {
+            Self::show_two_yaxis_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line plot: \"Axis equal\"")).build(&ui) {
-            Self::show_axis_equal_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: \"Axis equal\"").build(ui) {
+            Self::show_axis_equal_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line plot: Range conversions")).build(&ui) {
-            Self::show_conversions_plot(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: Range conversions").build(ui) {
+            Self::show_conversions_plot(ui, plot_ui);
         }
-        if CollapsingHeader::new(im_str!("Line plot: Linked plots")).build(&ui) {
-            self.show_linked_x_axis_plots(&ui, &plot_ui);
+        if CollapsingHeader::new("Line plot: Linked plots").build(ui) {
+            self.show_linked_x_axis_plots(ui, plot_ui);
         }
+    }
+}
+
+impl Default for LinePlotDemoState {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/implot-examples/examples-shared/src/scatter_plots.rs
+++ b/implot-examples/examples-shared/src/scatter_plots.rs
@@ -1,13 +1,11 @@
 //! This example demonstrates how scatter plots are to be used. For more general
 //! features of the libray, see the line_plots example.
 
-use imgui::{im_str, CollapsingHeader, Ui};
+use imgui::{CollapsingHeader, Ui};
 use implot::{push_style_var_f32, push_style_var_i32, Marker, Plot, PlotScatter, PlotUi, StyleVar};
 
 pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text(im_str!(
-        "This header just draws a scatter plot with as little code as possible."
-    ));
+    ui.text("This header just draws a scatter plot with as little code as possible.");
     let content_width = ui.window_content_region_width();
     Plot::new("Simple scatter plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -22,9 +20,7 @@ pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_custom_markers_plot(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text(im_str!(
-        "This header shows how markers can be used in scatter plots."
-    ));
+    ui.text("This header shows how markers can be used in scatter plots.");
     let content_width = ui.window_content_region_width();
     Plot::new("Multi-marker scatter plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -53,11 +49,11 @@ pub fn show_custom_markers_plot(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_demo_headers(ui: &Ui, plot_ui: &PlotUi) {
-    if CollapsingHeader::new(im_str!("Basic scatter plot")).build(&ui) {
-        show_basic_plot(&ui, &plot_ui);
+    if CollapsingHeader::new("Basic scatter plot").build(ui) {
+        show_basic_plot(ui, plot_ui);
     }
 
-    if CollapsingHeader::new(im_str!("Custom markers")).build(&ui) {
-        show_custom_markers_plot(&ui, &plot_ui);
+    if CollapsingHeader::new("Custom markers").build(ui) {
+        show_custom_markers_plot(ui, plot_ui);
     }
 }

--- a/implot-examples/examples-shared/src/stairs_plots.rs
+++ b/implot-examples/examples-shared/src/stairs_plots.rs
@@ -1,13 +1,11 @@
 //! This example demonstrates how stairs plots are to be used. They are almost the same as line
 //! plots, so head over to the line plots example for more info.
 //!
-use imgui::{im_str, CollapsingHeader, Ui};
+use imgui::{CollapsingHeader, Ui};
 use implot::{Plot, PlotStairs, PlotUi};
 
 pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text_wrapped(im_str!(
-        "This header just plots a stairs-style line with as little code as possible."
-    ));
+    ui.text_wrapped("This header just plots a stairs-style line with as little code as possible.");
     let content_width = ui.window_content_region_width();
     Plot::new("Simple stairs plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -22,7 +20,7 @@ pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_demo_headers(ui: &Ui, plot_ui: &PlotUi) {
-    if CollapsingHeader::new(im_str!("Stairs plot: Basic")).build(&ui) {
-        show_basic_plot(&ui, &plot_ui);
+    if CollapsingHeader::new("Stairs plot: Basic").build(ui) {
+        show_basic_plot(ui, plot_ui);
     }
 }

--- a/implot-examples/examples-shared/src/stem_plots.rs
+++ b/implot-examples/examples-shared/src/stem_plots.rs
@@ -1,11 +1,11 @@
 //! This example demonstrates how stem plots are to be used. For more general
 //! features of the libray, see the line_plots example.
 
-use imgui::{im_str, CollapsingHeader, Ui};
+use imgui::{CollapsingHeader, Ui};
 use implot::{Plot, PlotStems, PlotUi};
 
 pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text(im_str!("This header shows a simple stem plot."));
+    ui.text("This header shows a simple stem plot.");
     let content_width = ui.window_content_region_width();
     Plot::new("Stem plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -22,7 +22,7 @@ pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_demo_headers(ui: &Ui, plot_ui: &PlotUi) {
-    if CollapsingHeader::new(im_str!("Stem plots")).build(&ui) {
-        show_basic_plot(&ui, &plot_ui);
+    if CollapsingHeader::new("Stem plots").build(ui) {
+        show_basic_plot(ui, plot_ui);
     }
 }

--- a/implot-examples/examples-shared/src/text_plots.rs
+++ b/implot-examples/examples-shared/src/text_plots.rs
@@ -1,13 +1,11 @@
 //! This example demonstrates how the text plotting features are to be used. For more general
 //! features of the libray, see the line_plots example.
 
-use imgui::{im_str, CollapsingHeader, Ui};
+use imgui::{CollapsingHeader, Ui};
 use implot::{Plot, PlotText, PlotUi};
 
 pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
-    ui.text(im_str!(
-        "This header just plots some text with as little code as possible."
-    ));
+    ui.text("This header just plots some text with as little code as possible.");
     let content_width = ui.window_content_region_width();
     Plot::new("Simple text plot")
         // The size call could also be omitted, though the defaults don't consider window
@@ -29,7 +27,7 @@ pub fn show_basic_plot(ui: &Ui, plot_ui: &PlotUi) {
 }
 
 pub fn show_demo_headers(ui: &Ui, plot_ui: &PlotUi) {
-    if CollapsingHeader::new(im_str!("Text plot: Basic")).build(&ui) {
-        show_basic_plot(&ui, &plot_ui);
+    if CollapsingHeader::new("Text plot: Basic").build(ui) {
+        show_basic_plot(ui, plot_ui);
     }
 }

--- a/implot-examples/implot-glium-demo/Cargo.lock
+++ b/implot-examples/implot-glium-demo/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "d9fe5e32de01730eb1f6b7f5b51c17e03e2325bf40a74f754f04f130043affff"
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler32"
@@ -56,23 +56,24 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.56"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.4.3",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block"
@@ -82,15 +83,15 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bytemuck"
-version = "1.5.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4bad0c5981acc24bc09e532f35160f952e35422603f0563cd7a73c2c2e65a0"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "calloop"
@@ -99,14 +100,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b036167e76041694579972c28cf4877b4f92da222560ddb49008937b6a6727c"
 dependencies = [
  "log",
- "nix",
+ "nix 0.18.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -154,23 +155,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "cocoa"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54201c07dcf3a5ca33fececb8042aed767ee4bfd5a0235a8ceabcda956044b2"
-dependencies = [
- "bitflags",
- "block",
- "cocoa-foundation",
- "core-foundation 0.9.1",
- "core-graphics 0.22.2",
- "foreign-types",
- "libc",
- "objc",
+ "winapi",
 ]
 
 [[package]]
@@ -209,12 +194,6 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "core-foundation"
@@ -308,10 +287,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
+name = "crossbeam"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -319,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -330,12 +323,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -343,12 +335,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
+name = "crossbeam-queue"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -421,7 +422,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f15d1e3268f140f68d390637d5e76d849782d971ae7063e0da69fe9709a76"
 dependencies = [
- "libloading",
+ "libloading 0.6.7",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
+dependencies = [
+ "libloading 0.7.0",
 ]
 
 [[package]]
@@ -466,26 +476,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "gif"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02efba560f227847cb41463a7395c514d127d4f74fff12ef0137fff1b84b96c4"
+checksum = "5a668f699973d0f573d15749b7002a9ac9e1f9c6b220e7b165601334c173d8de"
 dependencies = [
  "color_quant",
  "weezl",
@@ -493,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "gl_generator"
@@ -510,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "glium"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77623b4b688e68ec5ce256dd45614e374d4bee6ecec964b790733bf2c05f8732"
+checksum = "506a2aa1564891d447ae5d1ba37519a8efd6d01ea3e7952da81aa30430c90007"
 dependencies = [
  "backtrace",
  "fnv",
@@ -526,13 +520,13 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae1cbb9176b9151c4ce03f012e3cd1c6c18c4be79edeaeb3d99f5d8085c5fa3"
+checksum = "762d6cd2e1b855d99668ebe591cc9058659d85ac39a9a2078000eb122ddba8f0"
 dependencies = [
  "android_glue",
  "cgl",
- "cocoa 0.23.0",
+ "cocoa",
  "core-foundation 0.9.1",
  "glutin_egl_sys",
  "glutin_emscripten_sys",
@@ -540,14 +534,14 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "lazy_static",
- "libloading",
+ "libloading 0.7.0",
  "log",
  "objc",
  "osmesa-sys",
  "parking_lot",
  "wayland-client",
  "wayland-egl",
- "winapi 0.3.9",
+ "winapi",
  "winit",
 ]
 
@@ -558,7 +552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2abb6aa55523480c4adc5a56bbaa249992e2dddb2fc63dc96e04a3355364c211"
 dependencies = [
  "gl_generator",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -598,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -613,9 +607,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
-version = "0.23.13"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293f07a1875fa7e9c5897b51aa68b2d8ed8271b87e1a44cb64b9c3d98aabbc0d"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -632,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "imgui"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cfcf6e3326886321c5d637caf1ce217006651059015fae372b1c49c0e722b2"
+checksum = "4edc4023dc7b1161e25ec9bcee478173f97d6f618a1d04eced2d559ce03119b4"
 dependencies = [
  "bitflags",
  "imgui-sys",
@@ -643,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "imgui-glium-renderer"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c295c510c0d7209cf2304741808425bcd8e421142679d2448a38d4aa51762f3"
+checksum = "dc90d919aaa1fb05e4c58f0c3dad4a65f9233c2026cf8a3c549f721f3092da2c"
 dependencies = [
  "glium",
  "imgui",
@@ -653,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "imgui-sys"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ca00be6b78bf02b57e91468cf19d08dfcc11d0fb3c2f3dc491c29404d8d330"
+checksum = "0914d5ebaec1086300b970defc7ed71edc2cf102bdc3dd75fd51179549d4455b"
 dependencies = [
  "cc",
  "chlorine",
@@ -663,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "imgui-winit-support"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d632440e05c964e8a7f00f2659c4f71c97897d8c38a77a0c2dc1f3fe8d632208"
+checksum = "86a8c368182829141da5d22c352684d01e64359daa1a4550df4a2976836aa8e3"
 dependencies = [
  "imgui",
  "winit",
@@ -708,20 +702,11 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -740,16 +725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,16 +737,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "libloading"
@@ -780,14 +749,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -818,9 +797,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
@@ -833,12 +812,18 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
 
 [[package]]
 name = "miniz_oxide"
@@ -851,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -861,52 +846,43 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
-name = "mio-extras"
-version = "2.0.6"
+name = "mio-misc"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+checksum = "0ddf05411bb159cdb5801bb10002afb66cb4572be656044315e363460ce69dc2"
 dependencies = [
- "lazycell",
+ "crossbeam",
+ "crossbeam-queue",
  "log",
  "mio",
- "slab",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
 name = "ndk"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb167c1febed0a496639034d0c76b3b74263636045db5489eee52143c246e73"
+checksum = "8794322172319b972f528bf90c6b467be0079f1fa82780ffb431088e741a73ab"
 dependencies = [
  "jni-sys",
  "ndk-sys",
@@ -916,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "ndk-glue"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf399b8b7a39c6fb153c4ec32c72fd5fe789df24a647f229c239aa7adb15241"
+checksum = "c5caf0c24d51ac1c905c27d4eda4fa0635bbe0de596b8f79235e0b17a4d29385"
 dependencies = [
  "lazy_static",
  "libc",
@@ -935,7 +911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d1c6307dc424d0f65b9b06e94f88248e6305726b14729fd67a5e47b2dc481d"
 dependencies = [
  "darling",
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -946,17 +922,6 @@ name = "ndk-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "nix"
@@ -971,13 +936,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "6.1.0"
+name = "nix"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6f70b46d6325aa300f1c7bb3d470127dfc27806d8ea6bf294ee0ce643ce2b1"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
 dependencies = [
  "memchr",
+ "minimal-lexical",
  "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1033,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -1043,11 +1030,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1084,15 +1071,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "osmesa-sys"
@@ -1114,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -1125,16 +1115,16 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1171,19 +1161,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.24"
+name = "proc-macro-crate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1224,15 +1224,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rusttype"
@@ -1246,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "same-file"
@@ -1279,9 +1282,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "shared_library"
@@ -1294,12 +1297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,18 +1304,18 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316e13a3eb853ce7bf72ad3530dc186cb2005c57c521ef5f4ada5ee4eed74de6"
+checksum = "4750c76fd5d3ac95fa3ed80fe667d6a3d8590a960e5b575b98eea93339a80b80"
 dependencies = [
  "andrew",
  "bitflags",
  "calloop",
- "dlib",
+ "dlib 0.4.2",
  "lazy_static",
  "log",
  "memmap2",
- "nix",
+ "nix 0.18.0",
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
@@ -1332,9 +1329,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1349,18 +1346,18 @@ checksum = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1374,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
 dependencies = [
  "jpeg-decoder",
- "miniz_oxide 0.4.3",
+ "miniz_oxide 0.4.4",
  "weezl",
 ]
 
@@ -1395,37 +1392,37 @@ checksum = "3e5d7cd7ab3e47dda6e56542f4bbf3824c15234958c6e1bd6aaa347e93499fdc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbdbe01d03b2267809f3ed99495b37395387fde789e0f2ebb78e8b43f75b6d7"
+checksum = "e3ab332350e502f159382201394a78e3cc12d0f04db863429260164ea40e0355"
 dependencies = [
  "bitflags",
  "downcast-rs",
  "libc",
- "nix",
+ "nix 0.20.0",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -1434,11 +1431,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-commons"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480450f76717edd64ad04a4426280d737fc3d10a236b982df7b1aee19f0e2d56"
+checksum = "a21817947c7011bbd0a27e11b17b337bfd022e8544b071a2641232047966fbda"
 dependencies = [
- "nix",
+ "nix 0.20.0",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -1446,20 +1443,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6eb122c160223a7660feeaf949d0100281d1279acaaed3720eb3c9894496e5f"
+checksum = "be610084edd1586d45e7bdd275fe345c7c1873598caa464c4fb835dee70fa65a"
 dependencies = [
- "nix",
+ "nix 0.20.0",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-egl"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c653507447113c967a1aeee413699acb42d96d6302ec967c6d51930eae8aa7f5"
+checksum = "99ba1ab1e18756b23982d36f08856d521d7df45015f404a2d7c4f0b2d2f66956"
 dependencies = [
  "wayland-client",
  "wayland-sys",
@@ -1467,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319a82b4d3054dd25acc32d9aee0f84fa95b63bc983fffe4703b6b8d47e01a30"
+checksum = "286620ea4d803bacf61fa087a4242ee316693099ee5a140796aaba02b29f861f"
 dependencies = [
  "bitflags",
  "wayland-client",
@@ -1479,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7010ba5767b3fcd350decc59055390b4ebe6bd1b9279a9feb1f1888987f1133d"
+checksum = "ce923eb2deb61de332d1f356ec7b6bf37094dc5573952e1c8936db03b54c03f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1490,26 +1487,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.28.3"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6793834e0c35d11fd96a97297abe03d37be627e1847da52e17d7e0e3b51cc099"
+checksum = "d841fca9aed7febf9bed2e9796c49bf58d4152ceda8ac949ebe00868d8f0feb8"
 dependencies = [
- "dlib",
+ "dlib 0.5.0",
  "lazy_static",
  "pkg-config",
 ]
 
 [[package]]
 name = "weezl"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a32b378380f4e9869b22f0b5177c68a5519f03b3454fde0b291455ddbae266c"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+checksum = "d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e"
 
 [[package]]
 name = "winapi"
@@ -1520,12 +1511,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1539,7 +1524,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1550,12 +1535,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winit"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4eda6fce0eb84bd0a33e3c8794eb902e1033d0a1d5a31bc4f19b1b4bbff597"
+checksum = "79610794594d5e86be473ef7763f604f2159cbac8c94debd00df8fb41e86c2f8"
 dependencies = [
  "bitflags",
- "cocoa 0.24.0",
+ "cocoa",
  "core-foundation 0.9.1",
  "core-graphics 0.22.2",
  "core-video-sys",
@@ -1565,7 +1550,7 @@ dependencies = [
  "libc",
  "log",
  "mio",
- "mio-extras",
+ "mio-misc",
  "ndk",
  "ndk-glue",
  "ndk-sys",
@@ -1573,20 +1558,11 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "raw-window-handle",
+ "scopeguard",
  "smithay-client-toolkit",
  "wayland-client",
- "winapi 0.3.9",
+ "winapi",
  "x11-dl",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -1622,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "xcursor"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08"
+checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
 dependencies = [
  "nom",
 ]
@@ -1637,6 +1613,6 @@ checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"

--- a/implot-examples/implot-glium-demo/Cargo.toml
+++ b/implot-examples/implot-glium-demo/Cargo.toml
@@ -11,12 +11,12 @@ publish = false
 
 [dependencies]
 clipboard = "0.5"
-glium = { version = "0.29", default-features = true }
+glium = { version = "0.30", default-features = true }
 image = "0.23"
-imgui-sys = "0.7.0"
-imgui = "=0.7.0"
-imgui-glium-renderer = "=0.7.0"
-imgui-winit-support = "=0.7.0"
+imgui-sys = "0.8.0"
+imgui = "=0.8.0"
+imgui-glium-renderer = "=0.8.0"
+imgui-winit-support = "=0.8.0"
 
 implot-sys = { path = "../../implot-sys" }
 implot = { path = "../../" }

--- a/implot-examples/implot-glium-demo/src/main.rs
+++ b/implot-examples/implot-glium-demo/src/main.rs
@@ -1,4 +1,4 @@
-use imgui::{im_str, Condition, Window};
+use imgui::{Condition, Window};
 use implot::Context;
 
 // The actual backend-specific code is in this.
@@ -22,23 +22,20 @@ fn main() {
             demo_state.show_demos(ui, &plot_ui);
         }
 
-        Window::new(im_str!("Welcome to the ImPlot-rs demo!"))
+        Window::new("Welcome to the ImPlot-rs demo!")
             .size([430.0, 450.0], Condition::FirstUseEver)
             .build(ui, || {
-                ui.checkbox(im_str!("Show C++ ImPlot demo window"), &mut showing_demo);
-                ui.checkbox(
-                    im_str!("Show Rust ImPlot demo windows"),
-                    &mut showing_rust_demo,
-                );
+                ui.checkbox("Show C++ ImPlot demo window", &mut showing_demo);
+                ui.checkbox("Show Rust ImPlot demo windows", &mut showing_rust_demo);
                 // TODO(4bb4) ... move windows by default so this is less confusing
-                ui.text_wrapped(im_str!(
+                ui.text_wrapped(
                     "Note that the windows are stacked, so move this one out of the way to see\
                      the ones beneath it. If you see something in the C++ demo window, but not\
                      in the Rust ImPlot demo window, that means the bindings are likely not   \
                      implemented yet. Feel free to open an issue if you are missing something \
                      in particular.
-                    "
-                ));
+                    ",
+                );
             });
     });
 }

--- a/implot-examples/implot-glium-demo/src/support/clipboard.rs
+++ b/implot-examples/implot-glium-demo/src/support/clipboard.rs
@@ -4,21 +4,19 @@
 //
 // Not my code. Originally by Joonas Javanainen and the ImGUI-rs contributors
 use clipboard::{ClipboardContext, ClipboardProvider};
-use imgui::{ClipboardBackend, ImStr, ImString};
+use imgui::ClipboardBackend;
 
 pub struct ClipboardSupport(ClipboardContext);
 
 pub fn init() -> Option<ClipboardSupport> {
-    ClipboardContext::new()
-        .ok()
-        .map(ClipboardSupport)
+    ClipboardContext::new().ok().map(ClipboardSupport)
 }
 
 impl ClipboardBackend for ClipboardSupport {
-    fn get(&mut self) -> Option<ImString> {
+    fn get(&mut self) -> Option<String> {
         self.0.get_contents().ok().map(|text| text.into())
     }
-    fn set(&mut self, text: &ImStr) {
-        let _ = self.0.set_contents(text.to_str().to_owned());
+    fn set(&mut self, text: &str) {
+        let _ = self.0.set_contents(text.to_owned());
     }
 }

--- a/implot-examples/implot-glium-demo/src/support/mod.rs
+++ b/implot-examples/implot-glium-demo/src/support/mod.rs
@@ -41,7 +41,7 @@ pub fn init(title: &str) -> System {
     imgui.set_ini_filename(None);
 
     if let Some(backend) = clipboard::init() {
-        imgui.set_clipboard_backend(Box::new(backend));
+        imgui.set_clipboard_backend(backend);
     } else {
         eprintln!("Failed to initialize clipboard");
     }
@@ -50,7 +50,7 @@ pub fn init(title: &str) -> System {
     {
         let gl_window = display.gl_window();
         let window = gl_window.window();
-        platform.attach_window(imgui.io_mut(), &window, HiDpiMode::Rounded);
+        platform.attach_window(imgui.io_mut(), window, HiDpiMode::Rounded);
     }
 
     let hidpi_factor = platform.hidpi_factor();
@@ -97,7 +97,7 @@ impl System {
             Event::MainEventsCleared => {
                 let gl_window = display.gl_window();
                 platform
-                    .prepare_frame(imgui.io_mut(), &gl_window.window())
+                    .prepare_frame(imgui.io_mut(), gl_window.window())
                     .expect("Failed to prepare frame");
                 gl_window.window().request_redraw();
             }

--- a/implot-examples/implot-wgpu-demo/Cargo.lock
+++ b/implot-examples/implot-wgpu-demo/Cargo.lock
@@ -263,6 +263,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,7 +338,7 @@ checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
 dependencies = [
  "bitflags",
  "libloading 0.7.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -374,22 +442,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -569,9 +621,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "imgui"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cfcf6e3326886321c5d637caf1ce217006651059015fae372b1c49c0e722b2"
+checksum = "4edc4023dc7b1161e25ec9bcee478173f97d6f618a1d04eced2d559ce03119b4"
 dependencies = [
  "bitflags",
  "imgui-sys",
@@ -580,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "imgui-sys"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ca00be6b78bf02b57e91468cf19d08dfcc11d0fb3c2f3dc491c29404d8d330"
+checksum = "0914d5ebaec1086300b970defc7ed71edc2cf102bdc3dd75fd51179549d4455b"
 dependencies = [
  "cc",
  "chlorine",
@@ -590,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "imgui-wgpu"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06d48d73d62ba5ecc91a1c389579d1a90c69b52a11b19268aa7c14f8baeefbf"
+checksum = "371e4849d2a564284413607d212e3c68419a7bdb77a6d52249590a1d44dfcb28"
 dependencies = [
  "bytemuck",
  "imgui",
@@ -603,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "imgui-winit-support"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d632440e05c964e8a7f00f2659c4f71c97897d8c38a77a0c2dc1f3fe8d632208"
+checksum = "86a8c368182829141da5d22c352684d01e64359daa1a4550df4a2976836aa8e3"
 dependencies = [
  "imgui",
  "winit",
@@ -670,15 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,16 +734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -720,12 +753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,7 +765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -748,7 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -800,6 +827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,45 +851,36 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
-name = "mio-extras"
-version = "2.0.6"
+name = "mio-misc"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+checksum = "0ddf05411bb159cdb5801bb10002afb66cb4572be656044315e363460ce69dc2"
 dependencies = [
- "lazycell",
+ "crossbeam",
+ "crossbeam-queue",
  "log",
  "mio",
- "slab",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -869,16 +896,15 @@ dependencies = [
  "log",
  "num-traits",
  "petgraph",
- "rose_tree",
  "spirv",
  "thiserror",
 ]
 
 [[package]]
 name = "ndk"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb167c1febed0a496639034d0c76b3b74263636045db5489eee52143c246e73"
+checksum = "8794322172319b972f528bf90c6b467be0079f1fa82780ffb431088e741a73ab"
 dependencies = [
  "jni-sys",
  "ndk-sys",
@@ -888,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "ndk-glue"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf399b8b7a39c6fb153c4ec32c72fd5fe789df24a647f229c239aa7adb15241"
+checksum = "c5caf0c24d51ac1c905c27d4eda4fa0635bbe0de596b8f79235e0b17a4d29385"
 dependencies = [
  "lazy_static",
  "libc",
@@ -907,7 +933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d1c6307dc424d0f65b9b06e94f88248e6305726b14729fd67a5e47b2dc481d"
 dependencies = [
  "darling",
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -918,17 +944,6 @@ name = "ndk-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "nix"
@@ -953,6 +968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -973,11 +997,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1039,7 +1063,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1082,6 +1106,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -1147,15 +1181,6 @@ name = "renderdoc-sys"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
-
-[[package]]
-name = "rose_tree"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd16c61e9205949fa4f8a22096705b4c2f8b8025b2ff67ff6c86afd854039ae"
-dependencies = [
- "petgraph",
-]
 
 [[package]]
 name = "rusttype"
@@ -1336,7 +1361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -1498,7 +1523,6 @@ dependencies = [
  "arrayvec",
  "js-sys",
  "log",
- "naga",
  "parking_lot",
  "raw-window-handle",
  "smallvec",
@@ -1563,7 +1587,7 @@ dependencies = [
  "renderdoc-sys",
  "thiserror",
  "wgpu-types",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1577,12 +1601,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -1590,12 +1608,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1609,7 +1621,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1620,9 +1632,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winit"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4eda6fce0eb84bd0a33e3c8794eb902e1033d0a1d5a31bc4f19b1b4bbff597"
+checksum = "79610794594d5e86be473ef7763f604f2159cbac8c94debd00df8fb41e86c2f8"
 dependencies = [
  "bitflags",
  "cocoa",
@@ -1635,7 +1647,7 @@ dependencies = [
  "libc",
  "log",
  "mio",
- "mio-extras",
+ "mio-misc",
  "ndk",
  "ndk-glue",
  "ndk-sys",
@@ -1643,20 +1655,11 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "raw-window-handle",
+ "scopeguard",
  "smithay-client-toolkit",
  "wayland-client",
- "winapi 0.3.9",
+ "winapi",
  "x11-dl",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]

--- a/implot-examples/implot-wgpu-demo/Cargo.toml
+++ b/implot-examples/implot-wgpu-demo/Cargo.toml
@@ -9,9 +9,9 @@ resolver = "2"
 implot = { path = "../../" }
 
 wgpu = "0.10"
-winit = "0.24" # opening windows and handling input
+winit = "0.25" # opening windows and handling input
 futures = "^0.3.5" # executing async functions using blocking executor
 imgui = "=0.8.0"
 imgui-winit-support = "=0.8.0" # connection of input (keys) to imgui
-imgui-wgpu = "=0.17.0"
+imgui-wgpu = "=0.17.1"
 examples-shared = { path = "../examples-shared" }

--- a/implot-examples/implot-wgpu-demo/Cargo.toml
+++ b/implot-examples/implot-wgpu-demo/Cargo.toml
@@ -11,7 +11,7 @@ implot = { path = "../../" }
 wgpu = "0.10"
 winit = "0.24" # opening windows and handling input
 futures = "^0.3.5" # executing async functions using blocking executor
-imgui = "=0.7.0"
-imgui-winit-support = "=0.7.0" # connection of input (keys) to imgui
+imgui = "=0.8.0"
+imgui-winit-support = "=0.8.0" # connection of input (keys) to imgui
 imgui-wgpu = "=0.17.0"
 examples-shared = { path = "../examples-shared" }

--- a/implot-examples/implot-wgpu-demo/src/main.rs
+++ b/implot-examples/implot-wgpu-demo/src/main.rs
@@ -1,4 +1,4 @@
-use imgui::{im_str, Condition, Window};
+use imgui::{Condition, Window};
 use implot::Context;
 
 // The actual backend-specific code is in this.
@@ -22,23 +22,20 @@ fn main() {
             demo_state.show_demos(ui, &plot_ui);
         }
 
-        Window::new(im_str!("Welcome to the ImPlot-rs demo!"))
+        Window::new("Welcome to the ImPlot-rs demo!")
             .size([430.0, 450.0], Condition::FirstUseEver)
             .build(ui, || {
-                ui.checkbox(im_str!("Show C++ ImPlot demo window"), &mut showing_demo);
-                ui.checkbox(
-                    im_str!("Show Rust ImPlot demo windows"),
-                    &mut showing_rust_demo,
-                );
+                ui.checkbox("Show C++ ImPlot demo window", &mut showing_demo);
+                ui.checkbox("Show Rust ImPlot demo windows", &mut showing_rust_demo);
                 // TODO(4bb4) ... move windows by default so this is less confusing
-                ui.text_wrapped(im_str!(
+                ui.text_wrapped(
                     "Note that the windows are stacked, so move this one out of the way to see\
                      the ones beneath it. If you see something in the C++ demo window, but not\
                      in the Rust ImPlot demo window, that means the bindings are likely not   \
                      implemented yet. Feel free to open an issue if you are missing something \
                      in particular.
-                    "
-                ));
+                    ",
+                );
             });
     });
 }

--- a/implot-sys-bindgen/Cargo.toml
+++ b/implot-sys-bindgen/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 bindgen = "0.57"
-imgui-sys = { version = "=0.7.0" }
+imgui-sys = { version = "=0.8.0" }

--- a/implot-sys/Cargo.toml
+++ b/implot-sys/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 links = "implot"
 
 [dependencies]
-imgui-sys = "=0.7.0"
+imgui-sys = "=0.8.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,8 @@ use implot_sys as sys;
 
 // TODO(4bb4) facade-wrap these?
 pub use self::{context::*, plot::*, plot_elements::*};
-use imgui::im_str;
-pub use sys::{ImPlotLimits, ImPlotPoint, ImPlotRange, ImVec2, ImVec4};
 use std::os::raw::c_char;
+pub use sys::{ImPlotLimits, ImPlotPoint, ImPlotRange, ImVec2, ImVec4};
 
 mod context;
 mod plot;
@@ -576,7 +575,7 @@ pub fn is_plot_y_axis_hovered(y_axis_choice: Option<YAxisChoice>) -> bool {
 
 /// Returns true if the given item in the legend of the current plot is hovered.
 pub fn is_legend_entry_hovered(legend_entry: &str) -> bool {
-    unsafe { sys::ImPlot_IsLegendEntryHovered(im_str!("{}", legend_entry).as_ptr() as *const c_char) }
+    unsafe { sys::ImPlot_IsLegendEntryHovered(legend_entry.as_ptr() as *const c_char) }
 }
 
 // --- Demo window -------------------------------------------------------------------------------


### PR DESCRIPTION
Upgraded to newer imgui release, removed `im_str!` and `ImString` usage in favor of using `std::ffi::CString`. Fixed a bunch of clippy lints along the way.

This does not bump the implot bindings yet, that is a separate step because of the issues discovered in https://github.com/4bb4/implot-rs/issues/19.